### PR TITLE
Update stand. output/error file name to *.geos.log

### DIFF
--- a/scripts/geos_chem_classic.sbatch
+++ b/scripts/geos_chem_classic.sbatch
@@ -47,7 +47,7 @@
 #          Any directory into which logs are being written must exist before
 #          running your job.
 #-------------------------------------------------------------------------------
-#SBATCH --output=%x.log
+#SBATCH --output=%x.geos.log
 
 #-------------------------------------------------------------------------------
 # partition - The SLURM partition to use for your job. SLURM partitions are


### PR DESCRIPTION
The file for the combined standard output and standard error log has historically had the ending *geos.log. Update the default to include this for continuity (e.g. for automated scripts that look for a *geos.log) and to differentiate the file values other  *.log files that may be outputted (e.g. HEMCO.log).